### PR TITLE
Fix bug in checkReusingChars method

### DIFF
--- a/src/Scorer.php
+++ b/src/Scorer.php
@@ -400,8 +400,9 @@ class Scorer
         $this->passwordScore['calculatedData']['reusingChars']['value'] = 0;
         $this->passwordScore['calculatedData']['reusingChars']['count'] = 0;
         $this->passwordScore['calculatedData']['reusingChars']['displayName'] = 'Reusing Characters';
+        $charMap = count_chars($this->password, 1);
         while ($i < \strlen($this->password)) {
-            foreach (count_chars($this->password, 1) as $i => $val) {
+            foreach ($charMap as $val) {
                 if ($val > 1) {
                     $this->passwordScore['calculatedData']['reusingChars']['value'] -= $val;
                     $this->passwordScore['calculatedData']['reusingChars']['count'] += 1;


### PR DESCRIPTION
The `checkReusingChars` method used a `foreach` loop inside a `while` loop, that was
redeclaring `$i`, the counter used in the while loop. This meant that in certain
cases, e.g if the maximum key value of `count_chars` was 90 (the ascii value of `Z`), and
the string length was 100, the while loop would never exit, as $i would flip between `90` & `91`

An example of the problem can be seen by testing with 
```
$test = str_repeat('Z', 100);
Scorer::score($test);
```